### PR TITLE
Functionality to disable and alias themes

### DIFF
--- a/block_theme_selector.php
+++ b/block_theme_selector.php
@@ -68,10 +68,22 @@ class block_theme_selector extends block_base {
                 $this->page->requires->js_call_amd('block_theme_selector/block_theme_selector', 'init', array());
 
                 // Add a dropdown to switch themes.
+                if (!empty($CFG->block_theme_selector_excludedthemes)) {
+                    $excludedthemes = explode(',', $CFG->block_theme_selector_excludedthemes);
+                } else {
+                    $excludedthemes = [];
+                }
                 $themes = core_component::get_plugin_list('theme');
                 $options = array();
                 foreach ($themes as $theme => $themedir) {
-                    $options[$theme] = ucfirst(get_string('pluginname', 'theme_' . $theme));
+                    if (in_array($theme, $excludedthemes)) {
+                        continue;
+                    }
+                    if (!empty($CFG->{"block_theme_selector_aliasedtheme_$theme"})) {
+                        $options[$theme] = $CFG->{"block_theme_selector_aliasedtheme_$theme"};
+                    } else {
+                        $options[$theme] = ucfirst(get_string('pluginname', 'theme_' . $theme));
+                    }
                 }
                 if ($CFG->block_theme_selector_urlswitch == 1) {
                     $current = core_useragent::get_device_type_theme('default');

--- a/lang/en/block_theme_selector.php
+++ b/lang/en/block_theme_selector.php
@@ -37,6 +37,10 @@ $string['windowsize'] = 'Window size:';
 
 // Settings.
 $string['siteconfigwarning'] = 'Only users with the \'moodle/site:config\' capability can change themes.  Or ask a user who has the capability to enable \'URL Switching\' for the block.';
+$string['aliasedtheme'] = 'Alias to use for theme {$a}';
+$string['aliasedtheme_desc'] = 'If text is entered here it will be used instead of the theme\'s name in the selector instead';
+$string['excludedthemes'] = 'Excluded themes';
+$string['excludedthemes_desc'] = 'Excluded themes will not be available to select.';
 $string['urlswitch'] = 'URL switching';
 $string['urlswitch_desc'] = 'Switch using the URL, requires the core theme \'allowthemechangeonurl\' setting to be set.';
 $string['urlswitchwarning'] = 'URL switching setting not configured, check block installation.';

--- a/settings.php
+++ b/settings.php
@@ -50,4 +50,19 @@ if ($ADMIN->fulltree) {
         2 => new lang_string('yes')   // Yes.
     );
     $settings->add(new admin_setting_configselect($name, $title, $description, $default, $choices));
+
+    $themes = core_component::get_plugin_list('theme');
+    $options = array();
+    foreach ($themes as $theme => $themedir) {
+        $options[$theme] = ucfirst(get_string('pluginname', 'theme_' . $theme));
+    }
+    $settings->add(new admin_setting_configmultiselect('block_theme_selector_excludedthemes',
+            get_string('excludedthemes', 'block_theme_selector'), get_string('excludedthemes_desc', 'block_theme_selector'),
+            array_keys($options), $options));
+
+    foreach ($themes as $theme => $themedir) {
+        $settings->add(new admin_setting_configtext("block_theme_selector_aliasedtheme_$theme",
+                get_string('aliasedtheme', 'block_theme_selector', $theme), get_string('aliasedtheme_desc', 'block_theme_selector'), '',
+                PARAM_TEXT));
+    }
 }

--- a/settings.php
+++ b/settings.php
@@ -58,7 +58,7 @@ if ($ADMIN->fulltree) {
     }
     $settings->add(new admin_setting_configmultiselect('block_theme_selector_excludedthemes',
             get_string('excludedthemes', 'block_theme_selector'), get_string('excludedthemes_desc', 'block_theme_selector'),
-            array_keys($options), $options));
+            '', $options));
 
     foreach ($themes as $theme => $themedir) {
         $settings->add(new admin_setting_configtext("block_theme_selector_aliasedtheme_$theme",


### PR DESCRIPTION
A client wanted to use your block but needed to be able to exclude themes they are not interested in and use aliases instead of the theme name itself. I thought these changes may be useful to other people.